### PR TITLE
fix: Upgrade markmap dependencies to resolve security vulnerabilities

### DIFF
--- a/mcp/mcp_servers/mcp_mind_map/create-bundle.js
+++ b/mcp/mcp_servers/mcp_mind_map/create-bundle.js
@@ -18,8 +18,18 @@ fs.mkdirSync(bundleDir, { recursive: true });
 
 console.log('Bundling markmap-cli with esbuild...');
 
+// Determine entry point - new versions use cli.js, old versions use index.js
+let entryPoint;
+try {
+  entryPoint = require.resolve('markmap-cli/dist/cli.js');
+  console.log('Using CLI entry point: dist/cli.js');
+} catch {
+  entryPoint = require.resolve('markmap-cli/dist/index.js');
+  console.log('Using legacy entry point: dist/index.js');
+}
+
 esbuild.build({
-  entryPoints: [require.resolve('markmap-cli/dist/index.js')],
+  entryPoints: [entryPoint],
   bundle: true,
   platform: 'node',
   target: 'node18',

--- a/mcp/mcp_servers/mcp_mind_map/markmap-wrapper.js
+++ b/mcp/mcp_servers/mcp_mind_map/markmap-wrapper.js
@@ -42,14 +42,20 @@ try {
   // Set up argv for the bundled CLI
   process.argv = [process.argv[0], 'markmap', ...args];
   
-  // Load the bundled CLI and call main() function
-  const { main } = require('./bundled/index.js');
+  // Load the bundled CLI
+  // The newer versions (cli.js) run directly on require, older versions (index.js) export a main function
+  const bundled = require('./bundled/index.js');
   
-  // Execute the main function (it returns a Promise)
-  main().catch(err => {
-    console.error('Markmap execution error:', err);
-    process.exit(1);
-  });
+  // If there's a main or markmap function, call it
+  const entryFn = bundled.main;
+  if (entryFn && typeof entryFn === 'function') {
+    entryFn().catch(err => {
+      console.error('Markmap execution error:', err);
+      process.exit(1);
+    });
+  }
+  // Otherwise, the CLI should have already run when we required it
+  
   
 } catch (error) {
   console.error('Failed to execute markmap:', error.message);

--- a/mcp/mcp_servers/mcp_mind_map/package.json
+++ b/mcp/mcp_servers/mcp_mind_map/package.json
@@ -8,10 +8,10 @@
     "markmap-standalone": "./markmap-wrapper.js"
   },
   "dependencies": {
-    "markmap-cli": "^0.16.0"
+    "markmap-cli": "^0.18.12"
   },
   "devDependencies": {
-    "esbuild": "^0.19.0",
+    "esbuild": "^0.27.2",
     "pkg": "^5.8.1"
   },
   "scripts": {


### PR DESCRIPTION
## Summary
Upgrades esbuild and markmap-cli dependencies to resolve security vulnerabilities while maintaining backward compatibility.

## Changes
- **esbuild**: Upgraded from ^0.19.0 to ^0.27.2
  - Fixes moderate severity vulnerability
- **markmap-cli**: Upgraded from ^0.16.0 to ^0.18.12
  - Fixes high severity vulnerabilities in hono dependency

## Technical Details
The markmap-cli 0.18.12 introduced breaking changes in its package structure:
- Entry point changed from `dist/index.js` to `dist/cli.js`
- Removed `main()` function export, now executes directly on require

**Solution:**
- Updated `create-bundle.js` to auto-detect the correct CLI entry point
- Updated `markmap-wrapper.js` to handle both old and new execution patterns
- Maintains backward compatibility with both package versions

## Testing
- ✅ Clean build successful
- ✅ Standalone executable (markmap-standalone.exe) verified working
- ✅ Full build script (build.bat) tested
- ✅ Python MCP server executable builds successfully
- ✅ All dependencies properly bundled

## Security Impact
Resolves npm audit vulnerabilities:
- esbuild: 1 moderate severity issue
- hono (via markmap-cli): 1 high severity issue

Only remaining vulnerability is in pkg (dev dependency, no fix available).