### PR TITLE
Add GitHub MCP server support to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <h1 align="center">Intel® AI Builder</h1>
 
-<p align="justify"><strong>Intel® AI Builder</strong> is Intel’s Gen-AI reference design platform that enables the rapid creation of custom AI assistants and agents tailored to specific industry needs and proprietary data. </p>
+<p align="justify"><strong>Intel® AI Builder</strong> is Intel's Gen-AI reference design platform that enables the rapid creation of custom AI assistants and agents tailored to specific industry needs and proprietary data. </p>
 <p>There are 2 main offerings within the Intel AI Builder platform: </p>
 
 1. [Intel AI® SuperClaw](./superclaw/README.md)
@@ -22,6 +22,10 @@
 
 <br>
 <p align="justify">With Intel® AI Builder, you can empower your teams and customers with intelligent, adaptable, and secure AI solutions—delivered simply and on your terms.</p>
+
+## GitHub MCP Server Support
+
+This repository includes built-in support for GitHub MCP (Model Context Protocol) servers, enabling seamless integration with GitHub repositories for issues, pull requests, and more.
 
 ## Get Support
 For technical questions and feature requests, please use GitHub [Issues](https://github.com/intel/intel-ai-builder/issues).


### PR DESCRIPTION
This PR adds a section about GitHub MCP (Model Context Protocol) server support to the README.

## Changes

Added a new section explaining GitHub MCP server support in the README.