### PR TITLE
Add section about future GitHub MCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,8 @@ For technical questions and feature requests, please use GitHub [Issues](https:/
 
 We would love to hear about your experience. Please contact us at [&#115;&#117;&#112;&#112;&#111;&#114;&#116;&#046;&#097;&#105;&#098;&#117;&#105;&#108;&#100;&#101;&#114;&#064;&#105;&#110;&#116;&#101;&#108;&#046;&#099;&#111;&#109;](mailto:support.aibuilder@intel.com).
 
+## Future GitHub MCP Support
+
+We're exploring integration with GitHub MCP (Model Context Protocol) to enable more powerful AI-driven development workflows. This would allow Intel AI Builder agents to interact with GitHub repositories, issues, pull requests, and other resources using standardized MCP tools.
+
 [Back to Top](#toc)


### PR DESCRIPTION
This PR adds a new section about future GitHub MCP (Model Context Protocol) support to the README.

## Summary
- Added "Future GitHub MCP Support" section explaining planned integration with GitHub MCP
- Describes how this would enable AI-driven development workflows with GitHub repositories