### PR TITLE
fix: bump mcp to 1.29.0 in mcp_google_hotel

### DIFF
--- a/superbuilder/mcp/mcp_servers/mcp_google_hotel/requirements.txt
+++ b/superbuilder/mcp/mcp_servers/mcp_google_hotel/requirements.txt
@@ -1,4 +1,4 @@
-mcp==1.23.0
+mcp==1.29.0
 fastapi>=0.68.0
 uvicorn>=0.15.0
 python-dotenv>=0.19.0


### PR DESCRIPTION
## Summary
- Upgrade \mcp\ from 1.23.0 to 1.29.0 in \mcp_google_hotel\ requirements.
- Brings in MCP Python SDK security fixes (1.27.2+ session binding, 1.28.1+ transport hardening) while staying on the 1.x line compatible with \FastMCP\.

## Test plan
- [x] \pip install -r superbuilder/mcp/mcp_servers/mcp_google_hotel/requirements.txt\
- [x] Start google_hotel MCP server and smoke-test tool calls
