### PR TITLE
fix: bump postcss to 8.5.25 in superbuilderclient

### DIFF
--- a/superbuilder/src/superbuilderclient/package-lock.json
+++ b/superbuilder/src/superbuilderclient/package-lock.json
@@ -3397,9 +3397,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -3514,9 +3514,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -3534,7 +3534,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary
- Update transitive \postcss\ from 8.5.16 to 8.5.25 in \superbuilder/src/superbuilderclient/package-lock.json\ (includes \
anoid\ 3.3.16 bump pulled in by postcss).
- Addresses [Dependabot alert #102](https://github.com/intel/intel-ai-builder/security/dependabot/102) (GHSA-r28c-9q8g-f849 path traversal in source map auto-loading; fixed in 8.5.18+).
- Same change as open Dependabot PR #94; this PR can replace #94 once merged.

## Test plan
- [x] \
pm ci\ in \superbuilder/src/superbuilderclient\
- [x] \
pm run build\ (or existing client CI) passes
