### PR TITLE
fix: batch Dependabot mcp and dompurify security updates

### DIFF
--- a/superbuilder/mcp/mcp_servers/mcp_google_flight/requirements.txt
+++ b/superbuilder/mcp/mcp_servers/mcp_google_flight/requirements.txt
@@ -1,4 +1,4 @@
-mcp==1.23.0
+mcp==1.29.0
 fastapi>=0.68.0
 uvicorn>=0.15.0
 python-dotenv>=0.19.0

--- a/superbuilder/mcp/mcp_servers/mcp_math/requirements.txt
+++ b/superbuilder/mcp/mcp_servers/mcp_math/requirements.txt
@@ -1,4 +1,4 @@
-mcp==1.23.0
+mcp==1.29.0
 fastapi>=0.68.0
 uvicorn>=0.15.0
 python-dotenv>=0.19.0

--- a/superbuilder/mcp/mcp_servers/mcp_mind_map/requirements.txt
+++ b/superbuilder/mcp/mcp_servers/mcp_mind_map/requirements.txt
@@ -1,4 +1,4 @@
-mcp==1.23.0
+mcp==1.29.0
 fastapi>=0.68.0
 uvicorn>=0.15.0
 python-dotenv>=0.19.0

--- a/superbuilder/src/superbuilderclient/package-lock.json
+++ b/superbuilder/src/superbuilderclient/package-lock.json
@@ -25,7 +25,7 @@
         "@tauri-apps/plugin-store": "^2.4.3",
         "ajv": "^8.20.0",
         "compare-versions": "^6.1.1",
-        "dompurify": "^3.4.11",
+        "dompurify": "^3.4.12",
         "i18next": "^26.3.3",
         "i18next-http-backend": "^4.0.0",
         "immer": "^11.1.8",
@@ -1768,9 +1768,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/superbuilder/src/superbuilderclient/package.json
+++ b/superbuilder/src/superbuilderclient/package.json
@@ -35,7 +35,7 @@
     "@tauri-apps/plugin-store": "^2.4.3",
     "ajv": "^8.20.0",
     "compare-versions": "^6.1.1",
-    "dompurify": "^3.4.11",
+    "dompurify": "^3.4.12",
     "i18next": "^26.3.3",
     "i18next-http-backend": "^4.0.0",
     "immer": "^11.1.8",


### PR DESCRIPTION
## Summary
Single PR for related open Dependabot items:

**MCP Python SDK (\mcp==1.29.0\)** in:
- \mcp_math\ — alerts [#87](https://github.com/intel/intel-ai-builder/security/dependabot/87), [#95](https://github.com/intel/intel-ai-builder/security/dependabot/95)
- \mcp_mind_map\ — alerts [#96](https://github.com/intel/intel-ai-builder/security/dependabot/96); supersedes Dependabot PR [#88](https://github.com/intel/intel-ai-builder/pull/88)
- \mcp_google_flight\ — alert [#97](https://github.com/intel/intel-ai-builder/security/dependabot/97)

Uses latest 1.x (1.29.0) compatible with existing \FastMCP\ servers; includes fixes from 1.27.2+ and 1.28.1+.

**DOMPurify (\^3.4.12\, lockfile 3.4.12)** in \superbuilderclient\ — alert [#99](https://github.com/intel/intel-ai-builder/security/dependabot/99); supersedes Dependabot PR [#89](https://github.com/intel/intel-ai-builder/pull/89).

## Test plan
- [x] \pip install -r\ for each updated MCP server requirements file; smoke-test servers
- [x] \
pm ci\ and build in \superbuilder/src/superbuilderclient\
